### PR TITLE
go the the same page of a different version

### DIFF
--- a/templates/navigation.tt
+++ b/templates/navigation.tt
@@ -45,7 +45,7 @@
 					[% FOREACH option_minor IN
 					ordered_versions.item(option_version) %]
 					<a class='dropdown-item minor-version'
-						href="/5.[% option_version %].[% option_minor %]">5.[%
+						href="/5.[% option_version %].[% option_minor %]/[% pageaddress %]">5.[%
 						option_version %].[% option_minor %]</a>
 					[% END %]
 					[% UNLESS loop.last %]


### PR DESCRIPTION
since the canonical pageaddress isn't version-specific it can easily appended to link to the correct page for a specific version.

If this works (haven't tested it) it should fix perldoc.perl.org#29 and perldoc.perl.org#82.