### PR TITLE
search: check for version-specific URL when making the search.json URL

### DIFF
--- a/Asset/assets/js/main.js
+++ b/Asset/assets/js/main.js
@@ -74,9 +74,10 @@
 			})
 			.then(function() {
 				console.log(currentURL, pathname.split('/')[1]);
-				if (pathname.split('/')[1].length === 0) {
+				if (!(/\d+\.\d/.test(pathname.split('/')[1]))) {
+                    // We are not on a version-specific page
 					currentURL = '/search.json';
-				} else {
+				} else {    // Use the version-specific search
 					currentURL = '/' + pathname.split('/')[1] + '/search.json';
 				}
 				fetch(currentURL)


### PR DESCRIPTION
Decide whether to use `/search.json` or `/<version>/search.json` based on whether the first part of the path looks like a version number.

I am using `/\d+\.\d/` as a proxy for a version-number format, for the sake of being liberal in what I accept.  This will detect `5.30.0`, but reject `perl.html` and `undefined` (since, in my browser console, `/undefined/.test(undefined)` is `true`!).

I think this should fix OpusVL/perldoc.perl.org#111 (**edit** and possibly also OpusVL/perldoc.perl.org#74).  I have tested it in the browser console, and it appears to work.  However, it's not obvious to me how to test it on the site without running `sitegen.pl` and creating the full site for _all_ Perl versions.  If there is a simpler way to test (e.g., only downloading one version), please let me know.

Thanks for considering this PR!