### PR TITLE
Make <h1>Perl 5 version 30.0 documentation</h1> smaller than function name <h1>

### DIFF
--- a/templates/default.tt
+++ b/templates/default.tt
@@ -57,8 +57,8 @@
                 <article class="col-sm-12 content">
                   <div class="documentation-wrapper">
                     <div id="perl_version">
-                      <h1 class='page-title'> Perl 5 version [% perl5_version %]
-                        documentation</h1>
+                      <h7 class='page-title'> Perl 5 version [% perl5_version %]
+                        documentation</h7>
                     </div>
                     [% INCLUDE $content_tt %]
                   </div>


### PR DESCRIPTION
Addresses issue #65

Since this issue has had no visible progress for many months, this quick fix will address the immediate problem.

Feel free to propose a better solution.